### PR TITLE
More documentation adjustments

### DIFF
--- a/gap/nofoma.gd
+++ b/gap/nofoma.gd
@@ -67,9 +67,9 @@
 #! your option) any later version.
 #!
 #! To install this package first unpack it inside some GAP root directory
-#! in the subdirectory 'pkg' (see the section 'Installing a GAP Package' of
+#! in the subdirectory `pkg` (see the section 'Installing a GAP Package' of
 #! the GAP reference manual). Then 'nofoma' can already be loaded and used
-#! (just type LoadPackage("nofoma");).
+#! (just type `LoadPackage("nofoma");`).
 #!
 #! @Section The main functions
 


### PR DESCRIPTION
Similar changes should be made elsewhere.

Also, the `<Ref>` and `<Cite>` elements should be used for
references to the GAP manual resp. to the bibliography.