### PR TITLE
JordanNormalform: don't return singular transformation matrices

### DIFF
--- a/gap/nofoma.gi
+++ b/gap/nofoma.gi
@@ -1017,7 +1017,9 @@ InstallGlobalFunction(JordanNormalformIrred, function(A,minpol)
     cobrank := blockdim;
     elDivs := [minpol];  
     while not cobrank = n do 
-        w := nfmFindVectorNotInSubspaceNC(COB{[1..cobrank]}{[1..n]});
+        w := nfmFindVectorNotInSubspaceNC(
+            EcheloniseMat(COB{[1..cobrank]}{[1..n]})
+        );
         spun := nfmSpinUntil(w,A,blockdim);
         CopySubMatrix(spun, COB, [1..blockdim],[cobrank+1..cobrank+blockdim],[1..n],[1..n]);
         cobrank := cobrank + blockdim;

--- a/tst/jnftest.tst
+++ b/tst/jnftest.tst
@@ -238,6 +238,12 @@ gap> Aconj := A^Matrix(GF(11^5),RandomInvertibleMat(20,GF(11^5)));;
 gap> A^Inverse(JordanNormalform(A)[1]) = Aconj^Inverse(JordanNormalform(Aconj)[1]);
 true
 
+## Scalar matrices must still produce an invertible change of basis, see issue #72
+gap> Reset(GlobalMersenneTwister,3);;
+gap> A := Z(5)^0 * IdentityMat(3,GF(5));;
+gap> DeterminantMat(JordanNormalform(A)[1]) = 0*Z(5);
+false
+
 ## Stop test
 gap> STOP_TEST("JordanNormalform");
 


### PR DESCRIPTION
The helper nfmFindVectorNotInSubspaceNC expects echelonised inputs.

Fixes #72

Co-authored-by: Codex <codex@openai.com>
