### PR TITLE
docs: remove text pointing to source code again

### DIFF
--- a/gap/nofoma.gd
+++ b/gap/nofoma.gd
@@ -482,8 +482,3 @@ DeclareGlobalFunction("RatFormStep1");
 
 DeclareGlobalFunction("RatFormStep1J");
 DeclareGlobalFunction("SquareFreePol");
-
-#! The above functions, as well as a number of further auxiliary functions,
-#! are all contained and defined in the file 'gap/nofoma.gi';
-#! in that file, you can also find further inline documentation for the
-#! auxiliary functions.


### PR DESCRIPTION
It had been removed in PR #80 and added back (by accident?) in
PR #85. Here is again my justification for removing it:

It was very unusual and IMHO of questionable use: experts don't
need to be pointed at the source code, and regular users should
maybe not be pointed at it either, at least not without some more
words of warning and caution?

---

If you really would like to keep this, fine: but I wanted to find
out explicitly whether it was an accidental reversal or by choice.

If it is intentional, then `<F>...</F>` should be used to format
the filename.