### PR TITLE
Added a Frobenius Normalform with invariant factors sorted in descending order

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -85,7 +85,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">= 4.12",
+  GAP := ">= 4.13",
   NeededOtherPackages := [
     ["AutPGrp", ">= 1.5"],
   ],

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 
 # The GAP package nofoma
 
-This package computes maximal vectors, the Frobenius normal form and
+This package computes the Frobenius normal form and
 the Jordan-Chevalley decomposition of a (square) matrix over any field
-that is available in GAP. In particular, it extends the already existing
-GAP function `MininmalPolynomial` by computing also a vector whose local
-minimal polynomial is equal to the minimal polynomial of a given matrix.
+that is available in GAP, along with the Jordan normal form and primary decompositions
+of matrices over finite fields.
 
 To install the package, just unpack the tar file inside the pkg directory
 of your GAP installation.

--- a/gap/nofoma.gd
+++ b/gap/nofoma.gd
@@ -97,31 +97,25 @@ DeclareInfoClass("Infonofoma");
 #! Furthermore 'RationalCanonicalFormTransform' sorts the invariant factors in ascending order, while <Ref Func="FrobeniusNormalForm"/>
 #! sorts them in descending order. 
 #! @BeginExampleSession
-#! gap> x:=RandomInvertibleMat(10, GF(5));;
-#! gap> T:=RationalCanonicalFormTransform(x);;
-#! gap> S:=TransposedMat(FrobeniusNormalForm(TransposedMat(x))[2]);;
-#! gap> Display(x^T);
-#!  . . . . . . . . . 4
-#!  1 . . . . . . . . .
-#!  . 1 . . . . . . . 2
-#!  . . 1 . . . . . . .
-#!  . . . 1 . . . . . 2
-#!  . . . . 1 . . . . 3
-#!  . . . . . 1 . . . 2
-#!  . . . . . . 1 . . 1
-#!  . . . . . . . 1 . 2
-#!  . . . . . . . . 1 3
-#! gap> Display(x^S);
-#!  . . . . . . . . . 4
-#!  1 . . . . . . . . .
-#!  . 1 . . . . . . . 2
-#!  . . 1 . . . . . . .
-#!  . . . 1 . . . . . 2
-#!  . . . . 1 . . . . 3
-#!  . . . . . 1 . . . 2
-#!  . . . . . . 1 . . 1
-#!  . . . . . . . 1 . 2
-#!  . . . . . . . . 1 3
+#! gap> A := [ [ 0*Z(5), Z(5)^3, 0*Z(5), Z(5)^0, Z(5)^3 ], 
+#! >   [ Z(5)^0, 0*Z(5), Z(5)^2, Z(5)^2, Z(5)^2 ], 
+#! >   [ Z(5), Z(5), 0*Z(5), Z(5)^0, Z(5)^3 ], 
+#! >   [ 0*Z(5), Z(5), Z(5)^2, Z(5)^2, Z(5) ], 
+#! >   [ Z(5)^3, Z(5)^3, Z(5)^0, Z(5)^3, Z(5)^0 ] ];;
+#! gap> T:=RationalCanonicalFormTransform(A);;
+#! gap> S:=TransposedMat(FrobeniusNormalForm(TransposedMat(A))[2]);;
+#! gap> Display(A^T);
+#!  . . . . 3
+#!  1 . . . 2
+#!  . 1 . . 3
+#!  . . 1 . 4
+#!  . . . 1 .
+#! gap> Display(A^S);
+#!  . . . . 3
+#!  1 . . . 2
+#!  . 1 . . 3
+#!  . . 1 . 4
+#!  . . . 1 .
 #! @EndExampleSession
 #! 
 #! Additionally, 'RationalCanonicalFormTransform' sorts 
@@ -170,22 +164,36 @@ DeclareGlobalFunction("FrobeniusNormalForm");
 
 #! @Arguments A
 #! @Description
-#! This function returns the same result as <Ref Func="FrobeniusNormalForm"/>, except that it 
-#! sorts the invariant factors of <M>A</M> in descending order, just as in 'RationalCanonicalFormTransform'. 
-#! Thus to get a drop in replacement for RationalCanonicalFormTransform, one just has to invert the conjugating 
-#! matrix produced by <Ref Func="FrobeniusNormalForm"/> and transpose the transformed matrix. 
+#! This function returns the same result as <Ref Func="FrobeniusNormalForm"/>, except that the invariant factors 
+#! are sorted in descending order and the companion matrices on the diagonal are transposed. Furthermore, if <M>P</M> is the 
+#! computed base change matrix, the Frobenius normal form is obtained by <M>P^{-1}AP</M> (instead of <M>PAP^{-1}</M>).
+#! This means that <M>P</M> can be used as a direct drop-in replacement for RationalCanonicalFormTransform. 
+#!
+#! Note that this function works by calling <Ref Func="FrobeniusNormalForm"/> and then modifying the computed 
+#! transformation matrix and is thus potentially less efficient than using
+#! the original function. 
 #! @BeginExampleSession
-#! gap> aa:=[[  0, -8, 12, 40,-36,  4,  0, 59, 15, -9],
-#! >         [ -2, -2, -2,  6,-11,  1, -1, 10,  1,  0],
-#! >         [  1,  5,  0, -6, 12, -2,  0,-12, -4,  2],
-#! >         [  0,  0,  0,  2,  0,  0,  0,  7,  0,  0],
-#! >         [  0,  2, -3, -7,  8, -1,  0, -7, -3,  2],
-#! >         [ -5, -4, -6, 18,-30,  2, -2, 35,  5, -1],
-#! >         [ -1, -6,  6, 20,-28,  3,  0, 24, 10, -6],
-#! >         [  0,  0,  0, -1,  0,  0,  0, -3,  0,  0],
-#! >         [  0,  0, -1, -2, -2,  0, -1, -7,  0,  0],
-#! >         [  0, -8,  9, 21,-36,  4, -2, 12, 12, -8]];;
-#! gap> frob := FrobeniusNormalFormDescending(A)[2];;
+#! gap> A := [ [ 0*Z(5), Z(5)^2, Z(5)^2, 0*Z(5), Z(5)^3, Z(5)^3, 0*Z(5), Z(5)^3, 
+#! >       0*Z(5), Z(5) ], 
+#! >   [ Z(5)^0, Z(5)^0, Z(5)^0, Z(5), Z(5)^3, Z(5), Z(5)^3, 0*Z(5), Z(5), 
+#! >       0*Z(5) ], 
+#! >   [ Z(5), 0*Z(5), 0*Z(5), Z(5)^3, Z(5)^2, Z(5)^0, 0*Z(5), Z(5)^0, 
+#! >       Z(5), Z(5)^2 ], 
+#! >   [ 0*Z(5), 0*Z(5), 0*Z(5), Z(5)^2, 0*Z(5), 0*Z(5), 0*Z(5), Z(5)^2, 
+#! >       0*Z(5), 0*Z(5) ], 
+#! >   [ 0*Z(5), Z(5)^2, Z(5)^2, Z(5)^0, Z(5)^0, Z(5)^3, 0*Z(5), Z(5)^0, 
+#! >       Z(5)^2, Z(5)^2 ], 
+#! >   [ 0*Z(5), Z(5), Z(5)^3, Z(5)^0, 0*Z(5), Z(5)^2, Z(5)^0, 0*Z(5), 
+#! >       0*Z(5), Z(5)^3 ], 
+#! >   [ Z(5)^3, Z(5)^3, Z(5), 0*Z(5), Z(5)^2, Z(5)^0, 0*Z(5), Z(5)^3, 
+#!>       0*Z(5), Z(5)^3 ], 
+#! >   [ 0*Z(5), 0*Z(5), 0*Z(5), Z(5)^3, 0*Z(5), 0*Z(5), 0*Z(5), Z(5)^2, 
+#! >       0*Z(5), 0*Z(5) ], 
+#! >   [ 0*Z(5), 0*Z(5), Z(5)^3, Z(5)^0, Z(5)^0, 0*Z(5), Z(5)^3, Z(5)^0, 
+#! >       0*Z(5), 0*Z(5) ], 
+#! >   [ 0*Z(5), Z(5)^2, Z(5)^3, Z(5), Z(5)^3, Z(5)^3, Z(5)^0, Z(5)^2, 
+#! >       Z(5)^2, Z(5)^2 ] ];;
+#! gap> frob := FrobeniusNormalFormLikeRCFT(A)[2];;
 #! gap> rat := RationalCanonicalFormTransform(A);;
 #! gap> Display(A^rat);
 #!  . . . 1 . . . . . .
@@ -198,7 +206,7 @@ DeclareGlobalFunction("FrobeniusNormalForm");
 #!  . . . . . . 1 . . .
 #!  . . . . . . . 1 . 1
 #!  . . . . . . . . 1 3
-#! gap> Display(TransposedMat(A^Inverse(frob)));
+#! gap> Display(A^frob);
 #!  . . . 1 . . . . . .
 #!  1 . . . . . . . . .
 #!  . 1 . . . . . . . .
@@ -210,7 +218,7 @@ DeclareGlobalFunction("FrobeniusNormalForm");
 #!  . . . . . . . 1 . 1
 #!  . . . . . . . . 1 3
 #! @EndExampleSession
-DeclareGlobalFunction("FrobeniusNormalFormDescending");
+DeclareGlobalFunction("FrobeniusNormalFormLikeRCFT");
 
 #! @Arguments A
 #! @Description

--- a/gap/nofoma.gd
+++ b/gap/nofoma.gd
@@ -94,14 +94,15 @@ DeclareInfoClass("Infonofoma");
 #! one can compute a change of basis matrix from A to a companion matrix of its minimal polynomial by computing 
 #! <M>v</M> multiplied with powers of <M>A</M> (i.e., <M>v</M>, <M>vA</M>, ...., <M>vA^(n-1)</M>). This approach
 #! follows GAP’s convention of right multiplication and yields a companion matrix in the form used by <Ref Func="FrobeniusNormalForm"/>.
-#! To transform one into the other, one can simply transpose the companion matrix.
+#! Furthermore 'RationalCanonicalFormTransform' sorts the invariant factors in ascending order, while <Ref Func="FrobeniusNormalForm"/>
+#! sorts them in descending order. 
 #! @BeginExampleSession
 #! gap> x:=RandomInvertibleMat(10, GF(5));;
 #! gap> T:=RationalCanonicalFormTransform(x);;
 #! gap> S:=TransposedMat(FrobeniusNormalForm(TransposedMat(x))[2]);;
 #! gap> Display(x^T);
-#! . . . . . . . . . 4
-#! 1 . . . . . . . . .
+#!  . . . . . . . . . 4
+#!  1 . . . . . . . . .
 #!  . 1 . . . . . . . 2
 #!  . . 1 . . . . . . .
 #!  . . . 1 . . . . . 2
@@ -110,7 +111,7 @@ DeclareInfoClass("Infonofoma");
 #!  . . . . . . 1 . . 1
 #!  . . . . . . . 1 . 2
 #!  . . . . . . . . 1 3
-#!gap> Display(x^S);
+#! gap> Display(x^S);
 #!  . . . . . . . . . 4
 #!  1 . . . . . . . . .
 #!  . 1 . . . . . . . 2
@@ -128,6 +129,7 @@ DeclareInfoClass("Infonofoma");
 #! <Ref Func="FrobeniusNormalForm"/> sorts them in 
 #! descending order. Consequently, the outputs of the two functions 
 #! agree up to a permutation of blocks and transposition.
+#! To get a drop in replacement for 'RationalCanonicalFormTransform', see <Ref Func="FrobeniusNormalFormDescending"/>.
 #! @BeginExampleSession
 #! gap> aa:=[[  0, -8, 12, 40,-36,  4,  0, 59, 15, -9],
 #! >         [ -2, -2, -2,  6,-11,  1, -1, 10,  1,  0],
@@ -165,6 +167,50 @@ DeclareInfoClass("Infonofoma");
 #!   [   0,   0,   0,   0,   0,   0,   1,   0,   0,   0 ] ]
 #! @EndExampleSession
 DeclareGlobalFunction("FrobeniusNormalForm");
+
+#! @Arguments A
+#! @Description
+#! This function returns the same result as <Ref Func="FrobeniusNormalForm"/>, except that it 
+#! sorts the invariant factors of <M>A</M> in descending order, just as in 'RationalCanonicalFormTransform'. 
+#! Thus to get a drop in replacement for RationalCanonicalFormTransform, one just has to invert the conjugating 
+#! matrix produced by <Ref Func="FrobeniusNormalForm"/> and transpose the transformed matrix. 
+#! @BeginExampleSession
+#! gap> aa:=[[  0, -8, 12, 40,-36,  4,  0, 59, 15, -9],
+#! >         [ -2, -2, -2,  6,-11,  1, -1, 10,  1,  0],
+#! >         [  1,  5,  0, -6, 12, -2,  0,-12, -4,  2],
+#! >         [  0,  0,  0,  2,  0,  0,  0,  7,  0,  0],
+#! >         [  0,  2, -3, -7,  8, -1,  0, -7, -3,  2],
+#! >         [ -5, -4, -6, 18,-30,  2, -2, 35,  5, -1],
+#! >         [ -1, -6,  6, 20,-28,  3,  0, 24, 10, -6],
+#! >         [  0,  0,  0, -1,  0,  0,  0, -3,  0,  0],
+#! >         [  0,  0, -1, -2, -2,  0, -1, -7,  0,  0],
+#! >         [  0, -8,  9, 21,-36,  4, -2, 12, 12, -8]];;
+#! gap> frob := FrobeniusNormalFormDescending(A)[2];;
+#! gap> rat := RationalCanonicalFormTransform(A);;
+#! gap> Display(A^rat);
+#!  . . . 1 . . . . . .
+#!  1 . . . . . . . . .
+#!  . 1 . . . . . . . .
+#!  . . 1 . . . . . . .
+#!  . . . . . . . . . 4
+#!  . . . . 1 . . . . 2
+#!  . . . . . 1 . . . 1
+#!  . . . . . . 1 . . .
+#!  . . . . . . . 1 . 1
+#!  . . . . . . . . 1 3
+#! gap> Display(TransposedMat(A^Inverse(frob)));
+#!  . . . 1 . . . . . .
+#!  1 . . . . . . . . .
+#!  . 1 . . . . . . . .
+#!  . . 1 . . . . . . .
+#!  . . . . . . . . . 4
+#!  . . . . 1 . . . . 2
+#!  . . . . . 1 . . . 1
+#!  . . . . . . 1 . . .
+#!  . . . . . . . 1 . 1
+#!  . . . . . . . . 1 3
+#! @EndExampleSession
+DeclareGlobalFunction("FrobeniusNormalFormDescending");
 
 #! @Arguments A
 #! @Description

--- a/gap/nofoma.gd
+++ b/gap/nofoma.gd
@@ -123,7 +123,7 @@ DeclareInfoClass("Infonofoma");
 #! <Ref Func="FrobeniusNormalForm"/> sorts them in 
 #! descending order. Consequently, the outputs of the two functions 
 #! agree up to a permutation of blocks and transposition.
-#! To get a drop in replacement for 'RationalCanonicalFormTransform', see <Ref Func="FrobeniusNormalFormDescending"/>.
+#! To get a drop in replacement for 'RationalCanonicalFormTransform', see <Ref Func="FrobeniusNormalFormLikeRCFT"/>.
 #! @BeginExampleSession
 #! gap> aa:=[[  0, -8, 12, 40,-36,  4,  0, 59, 15, -9],
 #! >         [ -2, -2, -2,  6,-11,  1, -1, 10,  1,  0],

--- a/gap/nofoma.gd
+++ b/gap/nofoma.gd
@@ -85,13 +85,43 @@ DeclareInfoClass("Infonofoma");
 #!   [   0,   0,   0,   0,  -2,   3,   0 ],
 #!   [   0,   0,   0,   0,   0,   0,   1 ] ]
 #! @EndExampleSession
-#! Note that this function is significantly more efficient
-#! than the existing 'RationalCanonicalFormTransform'. 
-#! However, the two functions yield slightly different results. While the blocks
-#! in 'RationalCanonicalFormTransform' are the companion matrices of the 
-#! invariant factors following the convention of matrix operation from the
-#! left, the blocks in <Ref Func="FrobeniusNormalForm"/> correspond to matrix operation
-#! from the right, as is convention in GAP. 
+#! Note that the Frobenius normal form is unique up to the choice of the companion matrices
+#! and the permutation of the blocks corresponding to the invariant factors. 
+#! So while this function is significantly more efficient than the existing 'RationalCanonicalFormTransform',
+#! the two functions yield slightly different results. 
+#! In 'RationalCanonicalFormTransform', the companion matrices are consistent with the output of 'CompanionMat'. 
+#! However, given an <M>n\times n</M> cyclic matrix <M>A</M>, along with a corresponding cyclic vector <M>v</M>, 
+#! one can compute a change of basis matrix from A to a companion matrix of its minimal polynomial by computing 
+#! <M>v</M> multiplied with powers of <M>A</M> (i.e., <M>v</M>, <M>vA</M>, ...., <M>vA^(n-1)</M>). This approach
+#! follows GAP’s convention of right multiplication and yields a companion matrix in the form used by <Ref Func="FrobeniusNormalForm"/>.
+#! To transform one into the other, one can simply transpose the companion matrix.
+#! @BeginExampleSession
+#! gap> x:=RandomInvertibleMat(10, GF(5));;
+#! gap> T:=RationalCanonicalFormTransform(x);;
+#! gap> S:=TransposedMat(FrobeniusNormalForm(TransposedMat(x))[2]);;
+#! gap> Display(x^T);
+#! . . . . . . . . . 4
+#! 1 . . . . . . . . .
+#!  . 1 . . . . . . . 2
+#!  . . 1 . . . . . . .
+#!  . . . 1 . . . . . 2
+#!  . . . . 1 . . . . 3
+#!  . . . . . 1 . . . 2
+#!  . . . . . . 1 . . 1
+#!  . . . . . . . 1 . 2
+#!  . . . . . . . . 1 3
+#!gap> Display(x^S);
+#!  . . . . . . . . . 4
+#!  1 . . . . . . . . .
+#!  . 1 . . . . . . . 2
+#!  . . 1 . . . . . . .
+#!  . . . 1 . . . . . 2
+#!  . . . . 1 . . . . 3
+#!  . . . . . 1 . . . 2
+#!  . . . . . . 1 . . 1
+#!  . . . . . . . 1 . 2
+#!  . . . . . . . . 1 3
+#! @EndExampleSession
 #! 
 #! Additionally, 'RationalCanonicalFormTransform' sorts 
 #! the invariant factors in ascending order, whereas the 

--- a/gap/nofoma.gi
+++ b/gap/nofoma.gi
@@ -382,9 +382,28 @@ InstallGlobalFunction(FrobeniusNormalForm,function(mat)
   fi;
 end);
 
+InstallGlobalFunction(FrobeniusNormalFormDescending, function(mat)
+  local frob, blocks, n, Perm, Trans, ind, d, i, l;
+  frob := FrobeniusNormalForm(mat);
+  blocks := frob[3];
+  n := NrRows(mat);
+  if Length(blocks) = 1 then
+    return frob;
+  fi;
+  Perm := ZeroMatrix(n, n, mat);
+  for i in [1..Length(blocks)-1] do
+    ind := blocks[i];
+    d   := blocks[i+1] - 1;
+    l   := d - ind + 1;
+    CopySubMatrix(IdentityMatrix(l, mat), Perm, [1..l], [ind..d], [1..l], [n-d+1..n-ind+1]);
+  od;
+  l := n - d;
+  CopySubMatrix(IdentityMatrix(l, mat), Perm, [1..l], [Last(blocks)..n], [1..l], [1..n-Last(blocks)+1]);
+  return [Reversed(frob[1]), TransposedMat(Perm)*frob[2], Reversed(frob[3])];
+end);
+
 # Returns the invariant factors of mat (i.e. the minimal polynomials of the
 # diagonal blocks in the rational canonical form of mat).
-# For details about this function, see nofoma.gd.
 InstallGlobalFunction(InvariantFactorsMat,function(mat)
   local A,A1,i,d,np,k,f,n,p;
   k:=DefaultFieldOfMatrix(mat);

--- a/gap/nofoma.gi
+++ b/gap/nofoma.gi
@@ -382,9 +382,9 @@ InstallGlobalFunction(FrobeniusNormalForm,function(mat)
   fi;
 end);
 
-InstallGlobalFunction(FrobeniusNormalFormDescending, function(mat)
+InstallGlobalFunction(FrobeniusNormalFormLikeRCFT, function(mat)
   local frob, blocks, n, Perm, Trans, ind, d, i, l;
-  frob := FrobeniusNormalForm(mat);
+  frob := FrobeniusNormalForm(TransposedMat(mat));
   blocks := frob[3];
   n := NrRows(mat);
   if Length(blocks) = 1 then
@@ -399,7 +399,7 @@ InstallGlobalFunction(FrobeniusNormalFormDescending, function(mat)
   od;
   l := n - d;
   CopySubMatrix(IdentityMatrix(l, mat), Perm, [1..l], [Last(blocks)..n], [1..l], [1..n-Last(blocks)+1]);
-  return [Reversed(frob[1]), TransposedMat(Perm)*frob[2], Reversed(frob[3])];
+  return [Reversed(frob[1]), TransposedMat(TransposedMat(Perm)*frob[2]), Reversed(frob[3])];
 end);
 
 # Returns the invariant factors of mat (i.e. the minimal polynomials of the


### PR DESCRIPTION
This should allow the user to use the function FrobeniusNormalForm as a (more or less) drop in replacement for RationalCanonicalFormTransform. (See #73).